### PR TITLE
Changed `maxlength` of language code fields to 5

### DIFF
--- a/options.html
+++ b/options.html
@@ -19,10 +19,10 @@
           Translate Text
         </td>
         <td class="col2">
-          From <input type="text" id="pageLang" maxlength="4" size="4" required/> 
+          From <input type="text" id="pageLang" maxlength="5" size="4" required/> 
         </td>
         <td class="col3">
-          To <input type="text" id="userLang"  maxlength="2" size="2" required/> 
+          To <input type="text" id="userLang"  maxlength="5" size="2" required/> 
         </td>
       </tr>
       <tr>
@@ -30,7 +30,7 @@
           Text To Speech
         </td>
         <td class="col2">
-          <input type="text" id="ttsLang"  maxlength="2" size="2" required/>
+          <input type="text" id="ttsLang"  maxlength="5" size="2" required/>
         </td>
         <td class="col3"></td>
       </tr>


### PR DESCRIPTION
For Chinese Simplified and Chinese Traditional the corresponding language codes are `zh-CN` and `zh-TW` and using only `zh` will cause Google Translate to fallback to English, so it's necessary to extend the `maxlength` for usability considerations. Still, the best solution is to replace the textboxes with drop-down menus.